### PR TITLE
Fix package.json browser property references.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "canvas-prebuilt": "^1.6"
   },
   "browser": {
-    "canvas": null,
-    "canvas-prebuilt": null
+    "canvas": false,
+    "canvas-prebuilt": false
   }
 }


### PR DESCRIPTION
Fixes #1. Tests still appear to pass with this change and it fixes the downstream Candela build.